### PR TITLE
Changes from background agent bc-d88b5557-6bdb-46c4-81e5-098adb5bb6ed

### DIFF
--- a/app/chooseCountries/index.tsx
+++ b/app/chooseCountries/index.tsx
@@ -667,7 +667,7 @@ export default function ChooseCountriesScreen({
   // Ref, który zapewni, że animacja zanikania uruchomi się tylko raz
   const hasInitialLoadFired = useRef(false);
   // Inicjalizacja oraz reakcja na zmianę trybu z ochroną przed zapętleniem
-  useEffect(() => {
+  useLayoutEffect(() => {
     const src = mode === "visited" ? visitedCountries : wishlistCountries;
     let differs = false;
     if (localSelectedCountries.size !== src.length) differs = true;
@@ -1105,10 +1105,18 @@ export default function ChooseCountriesScreen({
                       const modeBefore = selectionMode;
                       const snapshotBefore = new Set(localSelectedCountries);
                       saveForMode(modeBefore, snapshotBefore);
+                      // Ustaw natychmiast lokalne zaznaczenia dla następnego trybu,
+                      // aby były zsynchronizowane z ikonami
+                      const nextMode =
+                        modeBefore === "visited" ? "wishlist" : "visited";
+                      const nextSrc =
+                        nextMode === "visited"
+                          ? visitedCountries
+                          : wishlistCountries;
+                      setLocalSelectedCountries(new Set(nextSrc));
+                      setLocalCount(nextSrc.length);
                       // Przełącz tryb
-                      setSelectionMode((m) =>
-                        m === "visited" ? "wishlist" : "visited"
-                      );
+                      setSelectionMode(nextMode);
                       // Przywróć animacje selekcji natychmiast po commitcie
                       setTimeout(
                         () => setSuppressSelectionAnimations(false),

--- a/app/chooseCountries/index.tsx
+++ b/app/chooseCountries/index.tsx
@@ -1073,6 +1073,21 @@ export default function ChooseCountriesScreen({
               {/* Przycisk przełączający tryb visited <-> wishlist */}
               <Animated.View style={{ transform: [{ scale: scaleValue }] }}>
                 <Pressable
+                  onPressIn={() => {
+                    scaleValue.stopAnimation();
+                    Animated.timing(scaleValue, {
+                      toValue: 0.9,
+                      duration: 80,
+                      useNativeDriver: true,
+                    }).start();
+                  }}
+                  onPressOut={() => {
+                    Animated.timing(scaleValue, {
+                      toValue: 1,
+                      duration: 120,
+                      useNativeDriver: true,
+                    }).start();
+                  }}
                   onPress={() => {
                     // 1) Natychmiast przełącz stan UI (nie czekamy na animację przycisku)
                     setSuppressSelectionAnimations(true);
@@ -1091,28 +1106,14 @@ export default function ChooseCountriesScreen({
                     setLocalSelectedCountries(nextSrcSet);
                     setLocalCount(nextSrcSet.size);
                     setSelectionMode(nextMode);
-
-                    // 2) Animuj przycisk w tle, niezależnie od logiki
-                    Animated.sequence([
-                      Animated.timing(scaleValue, {
-                        toValue: 0.9,
-                        duration: 90,
-                        useNativeDriver: true,
-                      }),
-                      Animated.timing(scaleValue, {
-                        toValue: 1,
-                        duration: 120,
-                        useNativeDriver: true,
-                      }),
-                    ]).start();
-
-                    // 3) Przywróć animacje selekcji tuż po commitcie następnej klatki
+                    // 2) Przywróć animacje selekcji tuż po commitcie następnej klatki
                     requestAnimationFrame(() => setSuppressSelectionAnimations(false));
                   }}
                   style={[
                     styles.toggleButton,
                     { backgroundColor: theme.colors.primary },
                   ]}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
                 >
                   <Text
                     style={{

--- a/app/chooseCountries/index.tsx
+++ b/app/chooseCountries/index.tsx
@@ -146,7 +146,7 @@ const CountryItem = React.memo(
 
     // Wklej ten kod w miejsce całego bloku useEffect w CountryItem
 
-    useEffect(() => {
+    useLayoutEffect(() => {
       if (suppressSelectionAnimations) {
         // Natychmiastowa zmiana bez animacji dla przełączania trybu
         colorAnimation.stopAnimation();
@@ -368,11 +368,8 @@ export default function ChooseCountriesScreen({
 
   // Błyskawicznie aktualizuj stan ikon tuż przed committem layoutu
   useLayoutEffect(() => {
-    Animated.timing(modeAV, {
-      toValue: selectionMode === "wishlist" ? 1 : 0,
-      duration: 0,
-      useNativeDriver: true,
-    }).start();
+    modeAV.stopAnimation();
+    modeAV.setValue(selectionMode === "wishlist" ? 1 : 0);
   }, [selectionMode, modeAV]);
   const [isPopupVisible, setIsPopupVisible] = useState(true);
   const searchInputRef = useRef<TextInput>(null);
@@ -382,6 +379,9 @@ export default function ChooseCountriesScreen({
     wishlistCountries,
     setWishlistCountries,
   } = useCountries();
+  // Precompute sets to avoid rebuilding on every toggle
+  const visitedSet = useMemo(() => new Set(visitedCountries), [visitedCountries]);
+  const wishlistSet = useMemo(() => new Set(wishlistCountries), [wishlistCountries]);
   const initialVisitedCountriesRef = useRef(new Set(visitedCountries));
   const appState = useRef(AppState.currentState);
   const { updateAndHighlightCountries, applyCountryDiff } = useMapState();
@@ -668,34 +668,19 @@ export default function ChooseCountriesScreen({
   const hasInitialLoadFired = useRef(false);
   // Inicjalizacja oraz reakcja na zmianę trybu z ochroną przed zapętleniem
   useLayoutEffect(() => {
-    const src = mode === "visited" ? visitedCountries : wishlistCountries;
-    let differs = false;
-    if (localSelectedCountries.size !== src.length) differs = true;
-    else {
-      for (const c of src) {
-        if (!localSelectedCountries.has(c)) {
-          differs = true;
-          break;
-        }
-      }
-      if (!differs) {
-        for (const c of localSelectedCountries) {
-          if (!src.includes(c)) {
-            differs = true;
-            break;
-          }
-        }
-      }
-    }
-    if (differs) {
-      const initialSet = new Set(src);
-      setLocalSelectedCountries(initialSet);
-      initialVisitedCountriesRef.current = initialSet;
-      setLocalCount(initialSet.size);
+    const srcSet = mode === "visited" ? visitedSet : wishlistSet;
+    // Jeśli referencja lub rozmiar różni się, ustaw natychmiast nowy Set
+    if (
+      localSelectedCountries !== srcSet ||
+      localSelectedCountries.size !== srcSet.size
+    ) {
+      setLocalSelectedCountries(srcSet);
+      initialVisitedCountriesRef.current = srcSet;
+      setLocalCount(srcSet.size);
     } else {
       setLocalCount(localSelectedCountries.size);
     }
-  }, [mode, visitedCountries, wishlistCountries]);
+  }, [mode, visitedSet, wishlistSet]);
 
   // Czyszczenie licznika przy odmontowaniu
   useEffect(() => {
@@ -718,7 +703,6 @@ export default function ChooseCountriesScreen({
   const savingRef = useRef(false);
   const handleSelectCountry = useCallback(
     (countryCode: string) => {
-      if (savingRef.current) return;
       dismissKeyboard();
       setLocalSelectedCountries((currentSelected) => {
         const newSet = new Set(currentSelected);
@@ -775,7 +759,9 @@ export default function ChooseCountriesScreen({
         if (!finalSetSnapshot.has(c)) remove.push(c);
       });
       if (modeToSave === "visited") {
-        applyCountryDiff(add, remove, { immediate: true });
+        requestAnimationFrame(() => {
+          applyCountryDiff(add, remove, { immediate: true });
+        });
       }
       const currentSelectedArray = Array.from(finalSetSnapshot);
       const userDocRef = doc(db, "users", user.uid);
@@ -1088,6 +1074,25 @@ export default function ChooseCountriesScreen({
               <Animated.View style={{ transform: [{ scale: scaleValue }] }}>
                 <Pressable
                   onPress={() => {
+                    // 1) Natychmiast przełącz stan UI (nie czekamy na animację przycisku)
+                    setSuppressSelectionAnimations(true);
+                    const modeBefore = selectionMode;
+                    const snapshotBefore = new Set(localSelectedCountries);
+                    // Zapis bieżącego trybu po zakończeniu interakcji (nie blokuje UI)
+                    InteractionManager.runAfterInteractions(() => {
+                      saveForMode(modeBefore, snapshotBefore);
+                    });
+                    const nextMode =
+                      modeBefore === "visited" ? "wishlist" : "visited";
+                    const nextSrcSet =
+                      nextMode === "visited" ? visitedSet : wishlistSet;
+                    // Zaktualizuj wartość animacji ikony NATYCHMIAST
+                    modeAV.setValue(nextMode === "wishlist" ? 1 : 0);
+                    setLocalSelectedCountries(nextSrcSet);
+                    setLocalCount(nextSrcSet.size);
+                    setSelectionMode(nextMode);
+
+                    // 2) Animuj przycisk w tle, niezależnie od logiki
                     Animated.sequence([
                       Animated.timing(scaleValue, {
                         toValue: 0.9,
@@ -1099,30 +1104,10 @@ export default function ChooseCountriesScreen({
                         duration: 120,
                         useNativeDriver: true,
                       }),
-                    ]).start(() => {
-                      setSuppressSelectionAnimations(true);
-                      // Zapisz zmiany w bieżącym trybie przed przełączeniem
-                      const modeBefore = selectionMode;
-                      const snapshotBefore = new Set(localSelectedCountries);
-                      saveForMode(modeBefore, snapshotBefore);
-                      // Ustaw natychmiast lokalne zaznaczenia dla następnego trybu,
-                      // aby były zsynchronizowane z ikonami
-                      const nextMode =
-                        modeBefore === "visited" ? "wishlist" : "visited";
-                      const nextSrc =
-                        nextMode === "visited"
-                          ? visitedCountries
-                          : wishlistCountries;
-                      setLocalSelectedCountries(new Set(nextSrc));
-                      setLocalCount(nextSrc.length);
-                      // Przełącz tryb
-                      setSelectionMode(nextMode);
-                      // Przywróć animacje selekcji natychmiast po commitcie
-                      setTimeout(
-                        () => setSuppressSelectionAnimations(false),
-                        0
-                      );
-                    });
+                    ]).start();
+
+                    // 3) Przywróć animacje selekcji tuż po commitcie następnej klatki
+                    requestAnimationFrame(() => setSuppressSelectionAnimations(false));
                   }}
                   style={[
                     styles.toggleButton,


### PR DESCRIPTION
Synchronize selection highlights with mode icons to eliminate delay.

The `localSelectedCountries` state now updates immediately in `useLayoutEffect` and within the mode toggle handler, ensuring selections appear instantly when switching between "visited" and "wishlist" modes.

---
<a href="https://cursor.com/background-agent?bcId=bc-d88b5557-6bdb-46c4-81e5-098adb5bb6ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d88b5557-6bdb-46c4-81e5-098adb5bb6ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

